### PR TITLE
Sync sys darkmode

### DIFF
--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -1,7 +1,7 @@
 let imode = localStorage.getItem("isDark");
 
-if(imode === null)
-  imode = String(window.matchMedia('(prefers-color-scheme: dark)').matches);
+if(imode === null) // if mode never set by switching before (no localstorage var)
+  imode = String(window.matchMedia('(prefers-color-scheme: dark)').matches); // detect device's appearance mode
 
 let toogleStatus = document.getElementById('check-mode');
 let bodyElement = document.getElementsByTagName('body')[0];

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -1,5 +1,8 @@
 let imode = localStorage.getItem("isDark");
 
+if(imode === null)
+  imode = String(window.matchMedia('(prefers-color-scheme: dark)').matches);
+
 let toogleStatus = document.getElementById('check-mode');
 let bodyElement = document.getElementsByTagName('body')[0];
 let navLogo = document.getElementsByClassName('nav-logo')[0];


### PR DESCRIPTION
## Changes
When entering the site for the first time (the dark mode has never been set using the toggle button), it automatically detects the device's appearance mode (light or dark) and applies it to the site, it'll ignore the device mode if the user has already visited the site.

## How Has This Been Tested?
This has been tested on 2 devices Macbook/iPhone with Safari/Chrome, the code(device's mode detector) is supported on all browsers.

## Mentions
@wrussell1999 @ShrillShrestha

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build

## Checklist
- [x ] Coding style of this project is followed
- [ ] Change in documentation is required
- [ ] Documentation has been updated accordingly 
- [ ] Unit tests have been added to cover code change 
